### PR TITLE
main: use local paths instead of github API

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -28,6 +28,10 @@ inputs:
   token:
     description: 'Personal Access token with workflow permission'
     required: true
+  paths:
+    description: 'Glob like patterns where to look for actions - ; separated'
+    required: false
+    default: '.github/workflows/*.yml;.github/workflows/*.yaml'
 runs:
   using: 'docker'
   image: 'Dockerfile'


### PR DESCRIPTION
> for iterating the workflow files.
> By default it will look in .github/workflows/*.y(a)ml for files.

Not my code, but I'm using this fork because I have some workflows in different folders that I would also like to keep up to date, but the fork is lacking the latest updates.