### PR TITLE
use notice, not warning, for unsupported formats

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -152,9 +152,9 @@ class GitHubActionsVersionUpdater:
                         # we only need `user/repo` part from action_repository
                         action_repository = "/".join(action_location.split("/")[:2])
                     except ValueError:
-                        gha_utils.warning(
-                            f'Action "{action}" is in a wrong format, '
-                            "We only support community actions currently"
+                        gha_utils.notice(
+                            f'Action "{action}" is in an unsupported format. '
+                            "We only support community actions currently."
                         )
                         continue
 


### PR DESCRIPTION
My workflows include several locally-defined reusable workflows.  When used with this action, I get a lot of warnings:

```
[update-checker / github-actions-updater](http://example.com)
Action "./.github/workflows/pa11y.yml" is in a wrong format, We only support community actions currently
```

I think a notice is more appropriate than a warning here because in the case of a workflow in the local repository, the user probably can keep the version up-to-date themselves.  Also, I changed the phrasing from "wrong" to "unsupported" because there is nothing wrong with using local workflows.