### PR TITLE
remove warning on success

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -152,9 +152,6 @@ class GitHubActionsVersionUpdater:
                     )
 
                     if not new_version:
-                        gha_utils.warning(
-                            f"Could not find any new version for {action}. Skipping..."
-                        )
                         continue
 
                     updated_action = f"{action_location}@{new_version}"


### PR DESCRIPTION
I might be misunderstanding something, but currently, when I run this action on my repo, and my actions are up to date, I get lots of warnings like this:

```
[update-checker / github-actions-updater]
Could not find any new version for actions/checkout@v3.4.0. Skipping...
```

If the action is up to date, I don't think a warning should be printed to the action annotations.  I think nothing should be printed at all, because the check was successful-- an action was found, and it's up to date.

If I'm wrong and this should be a warning, please update the warning to explain what the problem is.