### PR TITLE
Fix the actions enclosed in quotes are not updated

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -171,7 +171,7 @@ class GitHubActionsVersionUpdater:
                             f'Updating "{action}" with "{updated_action}"...'
                         )
                         updated_workflow_data = re.sub(
-                            rf"({action})(\s+|$)",
+                            rf"({action})(\s+['\"]?|['\"]?$)",                      
                             rf"{updated_action}\2",
                             updated_workflow_data,
                             0,

--- a/src/main.py
+++ b/src/main.py
@@ -171,7 +171,7 @@ class GitHubActionsVersionUpdater:
                             f'Updating "{action}" with "{updated_action}"...'
                         )
                         updated_workflow_data = re.sub(
-                            rf"({action})(\s+['\"]?|['\"]?$)",                      
+                            rf"({action})(\s+['\"]?|['\"]?$)",
                             rf"{updated_action}\2",
                             updated_workflow_data,
                             0,


### PR DESCRIPTION
Fixed regular expressions to support quoted action names.

Related Issues https://github.com/saadmk11/github-actions-version-updater/issues/94

# Demo
[Original action file](https://github.com/kenz/github-action-updater-demo/blob/2a94c5329063d9dbd740c09b26cb36f52df3a3f6/.github/workflows/main.yaml)

## PullRequest created by Original version Github Actions Updater

Quoted actions are not updated. 
```yaml
+      - uses: actions/checkout@v4.1.7
      - name: Without quotation
+        uses: actions/setup-node@v4.0.2

      - name: With single quotation
        uses: 'actions/setup-node@v3.0.0'

      - name: With double quotation
        uses: "actions/setup-node@v3.0.0"
```

https://github.com/kenz/github-action-updater-demo/pull/10/files

## PullRequest created by supports quotation Version Github Actions Updater
Quoted actions also updated.  

```yaml
+      - uses: actions/checkout@v4.1.7
      - name: Without quotation
+        uses: actions/setup-node@v4.0.2

      - name: With single quotation
+        uses: 'actions/setup-node@v4.0.2'

      - name: With double quotation
+        uses: "actions/setup-node@v4.0.2"
```

https://github.com/kenz/github-action-updater-demo/pull/11/files