### PR TITLE
fix: move base image off EOL bullseye to bookworm

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.12-slim-bullseye
+FROM python:3.12-slim-bookworm
 
 LABEL "com.github.actions.name"="GitHub Actions Version Updater"
 LABEL "com.github.actions.description"="GitHub Actions Version Updater updates GitHub Action versions in a repository and creates a pull request with the changes."


### PR DESCRIPTION
## Summary
Debian bullseye reached end-of-life on **2026-08-31**. Its packages are being purged from the `bullseye-security` mirror, so the `apt-get install git` step in this action's container build now fails with `404 Not Found` / exit code 100. Every scheduled run of the action fails before any logic executes.

## Fix
`python:3.12-slim-bullseye` → `python:3.12-slim-bookworm`

Same Python 3.12 runtime, same slim profile — bookworm (Debian 12) is the current stable and its apt archives remain fully served (~2028 LTS horizon), avoiding a repeat of this class of failure for years.

## Reproduction
```
Err:4 http://deb.debian.org/debian-security bullseye-security/main amd64 libperl5.32 amd64 5.32.1-4+deb11u5
    404  Not Found
E: Failed to fetch .../libperl5.32_5.32.1-4+deb11u5_amd64.deb  404  Not Found
#7 ERROR: process "/bin/sh -c apt-get update && apt-get install ... git ..." did not complete successfully: exit code: 100
```
